### PR TITLE
Use CAAnimation for a smoother animation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include theos/makefiles/common.mk
 
 TWEAK_NAME = SpinSettings
 SpinSettings_FILES = Tweak.xm
-SpinSettings_FRAMEWORKS = UIKit Foundation CoreGraphics
+SpinSettings_FRAMEWORKS = UIKit Foundation CoreGraphics QuartzCore
 SpinSettings_CFLAGS = -Wno-error
 export GO_EASY_ON_ME := 1
 include $(THEOS_MAKE_PATH)/tweak.mk

--- a/SpinSettingsSettings/Resources/SpinSettingsSettings.plist
+++ b/SpinSettingsSettings/Resources/SpinSettingsSettings.plist
@@ -16,7 +16,7 @@
 			<key>cell</key>
 			<string>PSSwitchCell</string>
 			<key>default</key>
-			<false/>
+			<integer>15</integer>>
 			<key>defaults</key>
 			<string>com.joshdoctors.spinsettings</string>
 			<key>key</key>
@@ -30,7 +30,7 @@
 			<key>footerAlignment</key>
 			<integer>1</integer>
 			<key>footerText</key>
-			<string>*Default is 1.0</string>
+			<string>*Default is 15</string>
 		</dict>
         <dict>
             <key>cell</key>             <string>PSEditTextCell</string>

--- a/SpinSettingsSettings/Resources/SpinSettingsSettings.plist
+++ b/SpinSettingsSettings/Resources/SpinSettingsSettings.plist
@@ -16,7 +16,7 @@
 			<key>cell</key>
 			<string>PSSwitchCell</string>
 			<key>default</key>
-			<integer>15</integer>>
+			<integer>15</integer>
 			<key>defaults</key>
 			<string>com.joshdoctors.spinsettings</string>
 			<key>key</key>

--- a/SpinSettingsSettings/Resources/SpinSettingsSettings.plist
+++ b/SpinSettingsSettings/Resources/SpinSettingsSettings.plist
@@ -16,7 +16,7 @@
 			<key>cell</key>
 			<string>PSSwitchCell</string>
 			<key>default</key>
-			<integer>15</integer>
+			<false/>
 			<key>defaults</key>
 			<string>com.joshdoctors.spinsettings</string>
 			<key>key</key>
@@ -38,6 +38,7 @@
             <key>key</key>              <string>SSSpeed</string>
             <key>label</key>            <string>Spin Speed</string>
             <key>PostNotification</key> <string>com.joshdoctors.spinsettings/settingschanged</string>
+            <key>default</key>          <integer>15</integer>
         </dict>
 		<dict>
             <key>cell</key>             <string>PSButtonCell</string>

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -170,6 +170,21 @@ static BOOL enableTweak = NO;
 
 %new - (void)rotateImageView
 {
+	if (self.isSpinning)
+	{
+		CGFloat duration = [self isNumeric:SSSpeed] ? [SSSpeed floatValue] : 15;
+	   [UIView animateWithDuration:duration delay:0.0f options:UIViewAnimationOptionCurveLinear
+            animations:^{
+                self.dcImage.transform = CGAffineTransformRotate(self.dcImage.transform, M_PI / 2);
+            }
+            completion: ^(BOOL finished) {
+                if (finished) {
+                	[self.dcImage.layer removeAllAnimations];
+                	[self rotateImageView];
+                }
+            }];
+	}
+/*
 	if ((long)self.isSpinning && [self.dcImage.layer animationForKey:@"rotationAnimation"] == nil)
 	{
 		CGFloat duration = [self isNumeric:SSSpeed] ? [SSSpeed floatValue] : 15;
@@ -181,6 +196,7 @@ static BOOL enableTweak = NO;
 	    rotationAnimation.repeatCount = INFINITY;
 	    [self.dcImage.layer addAnimation:rotationAnimation forKey:@"rotationAnimation"];
 	}
+*/
 }
 %end
 

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -1,5 +1,7 @@
 #import <QuartzCore/QuartzCore.h>
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <substrate.h>
 
 #define kBundlePath @"/Library/PreferenceBundles/SpinSettingsSettings.bundle"
 #define SYS_VER_GREAT_OR_EQUAL(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:64] != NSOrderedAscending)
@@ -168,25 +170,16 @@ static BOOL enableTweak = NO;
 
 %new - (void)rotateImageView
 {
-	if ((long)self.isSpinning)
+	if ((long)self.isSpinning && [self.dcImage.layer animationForKey:@"rotationAnimation"] == nil)
 	{
-		[UIView beginAnimations:nil context:NULL];
-		[UIView animateWithDuration:10.0f delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
-			if ([self isNumeric:SSSpeed])
-			{
-				[self.dcImage setTransform:CGAffineTransformRotate(self.dcImage.transform,M_PI/((1.0/[SSSpeed doubleValue])*20))];
-			}
-			else
-				[self.dcImage setTransform:CGAffineTransformRotate(self.dcImage.transform,M_PI/20)];
-		}
-		completion:^(BOOL finished){
-			if (finished)
-			{
-				[self.dcImage.layer removeAllAnimations];
-				[self rotateImageView];
-			}
-		}];
-		[UIView commitAnimations];
+		CGFloat duration = [self isNumeric:SSSpeed] ? [SSSpeed floatValue] : 15;
+		//int rotations = 1;
+		CABasicAnimation* rotationAnimation = [CABasicAnimation animationWithKeyPath:@"transform.rotation.z"];
+	    rotationAnimation.toValue = [NSNumber numberWithFloat: M_PI * 2.0];
+	    rotationAnimation.duration = duration;
+	    rotationAnimation.cumulative = YES;
+	    rotationAnimation.repeatCount = INFINITY;
+	    [self.dcImage.layer addAnimation:rotationAnimation forKey:@"rotationAnimation"];
 	}
 }
 %end


### PR DESCRIPTION
All in the title. Changes to use a `CABasicAnimation` with a z rotation for a smoother animation, instead of using UIView animations. 
Also changes the default spin speed to 15 because at the previous rate of 1 it spins _super_ fast. 
